### PR TITLE
Run `svelte-kit sync` at `postinstall`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "svelte-promise-modals",
   "version": "0.0.1",
   "scripts": {
+    "postinstall": "svelte-kit sync",
     "dev": "vite dev",
     "build": "vite build && npm run package",
     "preview": "vite preview",


### PR DESCRIPTION
Resolves `[vite:esbuild] failed to resolve "extends":"./.svelte-kit/tsconfig.json" in /home/runner/work/svelte-promise-modals/svelte-promise-modals/tsconfig.json` in CI: https://github.com/mainmatter/svelte-promise-modals/actions/runs/5630683951/job/15256916354?pr=9