### PR TITLE
Rename output dir _app → app

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,6 +8,7 @@ const config = {
   preprocess: vitePreprocess(),
 
   kit: {
+    appDir: 'app',
     adapter: adapter({
       fallback: 'index.html',
     }),


### PR DESCRIPTION
Apparently this should prevent GH from 404'ing underscored stuff