### PR TITLE
Destroy modal when parent component gets destroyed

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,16 @@ let result: undefined = await openModal(MyModal);
 It's worth noting that since modals are opened as a descendant of `ModalContainer`, and therefore
 likely placed at the root layout, when the component the modal was opened from gets destroyed, such
 as when navigating away from a route, the modal will continue to live on. To automatically destroy
-the modal in such cases, use the `onDestroy` hook:
+the modal in such cases, create a modal context first, then use its `openModal` function instead of
+the one exported from the package. Modal context's `openModal` function hooks into `onDestroy`,
+ensuring all modals opened from that specific component gets destroyed when the component is
+unrendered.
 
 ```svelte
 <script>
-  import { onDestroy } from 'svelte';
+  import { useModalContext } from 'ember-promise-modals';
+
+  let { openModal } = useModalContext();
 
   async function handleOpenModal() {
     let modal = openModal(FooModal);

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -1,5 +1,5 @@
 import deepmerge from 'deepmerge';
-import type { ComponentType, SvelteComponent } from 'svelte';
+import { type ComponentType, onDestroy, type SvelteComponent } from 'svelte';
 import { derived, get, writable } from 'svelte/store';
 
 import { Modal } from './modal';
@@ -36,6 +36,37 @@ export const openModal = <T extends SvelteComponent>(
 
   return modal;
 };
+
+export function useModalContext() {
+  let modals: Modal<any>[] = [];
+
+  onDestroy(() => {
+    while (modals.length) {
+      modals.pop()?.close();
+    }
+  });
+
+  return {
+    openModal<T extends SvelteComponent>(
+      ...args: Parameters<typeof openModal<T>>
+    ): ReturnType<typeof openModal<T>> {
+      let modal = openModal(...args);
+
+      modals.push(modal);
+
+      modal.then((value) => {
+        let modalIndex = modals.indexOf(modal);
+        if (modalIndex > -1) {
+          modals.splice(modalIndex, 1);
+        }
+
+        return value;
+      });
+
+      return modal;
+    },
+  };
+}
 
 export const removeFromStack = (modal: unknown) => {
   stack.update(($stack) => $stack.filter((m) => m !== modal));

--- a/tests-ct/TestApp.svelte
+++ b/tests-ct/TestApp.svelte
@@ -3,6 +3,16 @@
   import { openModal } from '$lib/service';
 
   import TestModal from './TestModal.svelte';
+  import Wrapper from './Wrapper.svelte';
+
+  let win: any = window;
+  win.handle = {} as Record<string, any>;
+
+  let showWrapper = true;
+
+  win.handle.hideWrapper = () => {
+    showWrapper = false;
+  };
 
   export let modalContainerOptions = {};
   export let modalProps: any;
@@ -21,5 +31,17 @@
 <button data-testid="open-modal-button" type="button" on:click={() => openFooModal()}>
   Open Modal
 </button>
+
+{#if showWrapper}
+  <Wrapper let:openModal>
+    <button
+      on:click={() => openModal(TestModal)}
+      data-testid="open-modal-using-context-button"
+      type="button"
+    >
+      Open Using Context
+    </button>
+  </Wrapper>
+{/if}
 
 <ModalContainer options={modalContainerOptions} />

--- a/tests-ct/Wrapper.svelte
+++ b/tests-ct/Wrapper.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { useModalContext } from '$lib/service';
+
+  let { openModal } = useModalContext();
+</script>
+
+<slot {openModal} />

--- a/tests-ct/basics.spec.js
+++ b/tests-ct/basics.spec.js
@@ -15,7 +15,7 @@ test.describe('Basics', () => {
     await expect(page.getByTestId('backdrop')).toBeHidden();
     await expect(page.getByTestId('spm-modal')).toBeHidden();
 
-    await page.getByText('Open Modal').click();
+    await page.getByTestId('open-modal-button').click();
 
     await expect(page.getByTestId('backdrop')).toBeVisible();
     await expect(page.getByTestId('spm-modal')).toBeVisible();

--- a/tests-ct/modal-context.spec.js
+++ b/tests-ct/modal-context.spec.js
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/experimental-ct-svelte';
+
+import TestApp from './TestApp.svelte';
+
+test.describe('Modal Context', () => {
+  test.beforeEach(async ({ page }) => {
+    // Reduced motion will speed up animations which comes handy for testing
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+  });
+
+  test('removing the parent component removes the modal as well', async ({ mount, page }) => {
+    await mount(TestApp);
+
+    await expect(page.getByTestId('backdrop')).toBeHidden();
+    await expect(page.getByTestId('spm-modal')).toBeHidden();
+
+    await page.getByText('Open Using Context').click();
+
+    await expect(page.getByTestId('backdrop')).toBeVisible();
+    await expect(page.getByTestId('spm-modal')).toBeVisible();
+
+    await page.evaluateHandle(() => window.handle.hideWrapper());
+
+    await expect(page.getByTestId('backdrop')).toBeHidden();
+    await expect(page.getByTestId('spm-modal')).toBeHidden();
+  });
+});


### PR DESCRIPTION
Adds `useModalContext` function to create modal contexts from which the modal can be auto-destroyed