### PR TITLE
Add support for custom `className`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ By default, the animations are dropped when `prefers-reduced-motion` is detected
 ### Custom animations
 
 To override the animation for a specific modal, an `options` object containing
-a custom `className` can be handed to the `.open()` method.
+a custom `className` can be handed to the `openModal()` method.
 
 ```js
 openModal(
@@ -193,11 +193,6 @@ openModal(
   {
     // custom class, see below for example
     className: 'custom-modal',
-    // optional: name the animation triggered by the custom CSS class
-    //           animations ending in "-out" are detected by default!
-    //           You most likely do not have to do this unless you absolutely
-    //           can't have an animation ending in '-out'
-    animationKeyframesOutName: 'custom-animation-name-out',
     // optional: a hook that is called when the closing animation of
     //           the modal (so not the backdrop) has finished.
     onAnimationModalOutEnd: () => {},

--- a/src/lib/Modal.svelte
+++ b/src/lib/Modal.svelte
@@ -18,6 +18,7 @@
   let animationEnd: AnimationEndHandler | null = null;
 
   let focusTrapOptions: FocusTrapOptions;
+  let optionsClassName = modal.options.className ?? '';
 
   onMount(async () => {
     addFocusTrap();
@@ -142,7 +143,7 @@ component. Don't style them here, always use a separate local class! -->
 <div class="spm-modal-container modal-container">
   <div
     data-testid="spm-modal"
-    class="spm-modal modal"
+    class="spm-modal modal {optionsClassName}"
     class:spm-out={isAnimatingOut}
     bind:this={modalElement}
   >

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -27,10 +27,10 @@ export const updateOptions = (userOptions: Partial<ModalOptions>) => {
 
 export const openModal = <T extends SvelteComponent>(
   component: ComponentType<T>,
-  props?: PropsWithoutCloseModal<T>,
+  props?: PropsWithoutCloseModal<T> | null, // `null` is a convenience for when you don't want to pass any props but do want to pass options
   options?: ModalOptions
 ): Modal<T> => {
-  let modal: Modal<T> = new Modal(component, props, options);
+  let modal: Modal<T> = new Modal(component, props ?? undefined, options);
 
   stack.update((modals) => [...modals, modal]);
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -4,6 +4,7 @@ import type { ComponentProps, SvelteComponent } from 'svelte';
 export type ModalOptions = {
   onAnimationModalOutEnd?(): void;
   focusTrapOptions?: FocusTrapOptions;
+  className?: string;
 };
 
 export type FocusTrapOptions = FocusTrapOptions;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,29 +2,16 @@
   import '$lib/style.css';
   import './app.css';
 
-  import { browser } from '$app/environment';
   import ModalContainer from '$lib/ModalContainer.svelte';
-  import { destroyModals, openModal } from '$lib/service';
+  import { openModal } from '$lib/service';
+  import type { ModalOptions } from '$lib/types';
 
   import FooComponent from './FooComponent.svelte';
   import logo from './svelte-promise-modals-logo.svg';
 
-  type PlaywrightWindow = Window & {
-    modalOptions?: object;
-    modalResult?: unknown;
-    modals?: unknown;
-    destroyModals?: unknown;
-  };
-
-  if (browser) {
-    (window as PlaywrightWindow).destroyModals = destroyModals;
-  }
-
-  let modalOptions = (browser && (window as PlaywrightWindow).modalOptions) || {};
-
-  async function openFooModal() {
-    let result = await openModal(FooComponent);
-    (window as PlaywrightWindow).modalResult = result;
+  async function openFooModal(options?: ModalOptions) {
+    let result = await openModal(FooComponent, null, options);
+    console.log(`Modal result: ${JSON.stringify(result)}`);
   }
 </script>
 
@@ -82,4 +69,4 @@
   </p>
 </main>
 
-<ModalContainer options={modalOptions} />
+<ModalContainer />

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -17,7 +17,7 @@
 }
 
 /* this className will be added to the modal when the modal should be animated out */
-.from-bottom.epm-out {
+.from-bottom.spm-out {
   opacity: 0;
   transform: translate(0, calc(50vh + 50%));
   animation: from-bottom-out var(--epm-animation-modal-out-duration) ease-in;
@@ -53,14 +53,14 @@
 .from-top {
   opacity: 1;
   transform: translate(0, 0);
-  animation: from-top-in var(--epm-animation-modal-in-duration) ease-out;
+  animation: from-top-in var(--spm-animation-modal-in-duration) ease-out;
 }
 
 /* this className will be added to the modal when the modal should be animated out */
-.from-top.epm-out {
+.from-top.spm-out {
   opacity: 0;
   transform: translate(0, calc(-50vh - 50%));
-  animation: from-top-out var(--epm-animation-modal-out-duration) ease-in;
+  animation: from-top-out var(--spm-animation-modal-out-duration) ease-in;
 }
 
 @keyframes from-top-in {

--- a/tests-ct/basics.spec.js
+++ b/tests-ct/basics.spec.js
@@ -141,4 +141,24 @@ test.describe('Basics', () => {
     await page.waitForSelector('body.spm-animating');
     await page.waitForSelector('body:not(.spm-animating)');
   });
+
+  test('passing `className` adds the passed class to the `.spm-modal` element', async ({
+    mount,
+    page,
+  }) => {
+    await mount(TestApp, {
+      props: {
+        openModalOptions: {
+          className: 'foo',
+        },
+      },
+    });
+
+    await expect(page.getByTestId('spm-modal.foo')).toHaveCount(0);
+
+    await page.getByText('Open Modal').click();
+
+    await page.waitForSelector('.spm-modal.foo');
+    await expect(page.getByTestId('spm-modal')).toBeVisible();
+  });
 });


### PR DESCRIPTION
The docs already stated this is possible, but it didn't make it to the codebase for some reason 🤷 

Also,
- Allows `null` to be passed as props, when no props are passed, but options are
- Removes unsupported `animationKeyframesOutName` option from the docs
- Tidies up the example app a bit