### PR TITLE
fix: prerendering and small errors in +page.svelte

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,7 +83,7 @@
         let result = await openModal(FooComponent);
         console.log(result); // Whatever the modal returned when it was closed
       }
-    <\/script>
+    <`+dedent`/script>
 
     <button type="button" on:click={() => openFooModal()}>
       A simple modal with a button to close it

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,7 +18,7 @@
   import SyntaxHighlight from './SyntaxHighlight.svelte';
 
   async function openFooModal(data?: unknown, options?: ModalOptions) {
-    let result = await openModal(FooComponent, data ?? null, options);
+    let result = await openModal(FooComponent, { data }, options);
     console.log(`Modal result: ${JSON.stringify(result)}`);
   }
 </script>
@@ -83,7 +83,7 @@
         let result = await openModal(FooComponent);
         console.log(result); // Whatever the modal returned when it was closed
       }
-    </script>
+    <\/script>
 
     <button type="button" on:click={() => openFooModal()}>
       A simple modal with a button to close it

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,9 +9,7 @@ const config = {
 
   kit: {
     appDir: 'app',
-    adapter: adapter({
-      fallback: 'index.html',
-    }),
+    adapter: adapter(),
   },
 };
 


### PR DESCRIPTION
I've escaped the </script> in the url because that messes with the svelte compiler (and the language server) and updated how it was passing data to openModals(FooComponent) since it needed that in an object.