### PR TITLE
Fix typescript openmodal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,18 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
 
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wyvox/action-setup-pnpm@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: pnpm install
+      - run: pnpm check
+
   tests_e2e:
     name: Run end-to-end tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: pnpm install
-      - run: pnpm check
+      - run: cp svelte-promise-modals/.env.example svelte-promise-modals/.env && pnpm -F svelte-promise-modals build && pnpm check
 
   tests_e2e:
     name: Run end-to-end tests

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "pnpm -F svelte-promise-modals test:unit --run && pnpm -F test-app test:e2e",
     "lint": "pnpm -r /lint/",
     "format": "pnpm -r /format/",
+    "check": "pnpm -r /check/",
     "test:visual": "pnpm docker:build && pnpm docker:e2e",
     "docker:build": "docker buildx build . --build-arg \"DOCKER_USER=$(id -u):$(id -g)\" -f dev.Dockerfile --tag spm-visual --load",
     "docker:e2e": "docker run -v \"$(pwd)/:/app\" -u $(id -u):$(id -g) -i --rm spm-visual pnpm -F test-app test:e2e"

--- a/svelte-promise-modals/package.json
+++ b/svelte-promise-modals/package.json
@@ -12,7 +12,6 @@
     "prepublishOnly": "pnpm package",
     "changelog": "lerna-changelog",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test:unit": "vitest",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write . &&  eslint . --fix"
@@ -40,7 +39,7 @@
     "focus-trap": "^7.3.1"
   },
   "peerDependencies": {
-    "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0"
+    "svelte": "^5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/svelte-promise-modals/src/lib/ModalContainer.svelte
+++ b/svelte-promise-modals/src/lib/ModalContainer.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import { run } from 'svelte/legacy';
 
   import Modal from './Modal.svelte';
   import { animating, destroyModals, stack, updateOptions } from './service.svelte';
@@ -9,10 +8,12 @@
     options?: Record<string, any>;
   }
 
-  let { options = {} }: Props = $props();
+  let { options }: Props = $props();
 
-  run(() => {
-    updateOptions(options);
+  $effect(() => {
+    if (options) {
+      updateOptions(options);
+    }
   });
 
   onMount(() => {

--- a/svelte-promise-modals/src/lib/service.svelte.ts
+++ b/svelte-promise-modals/src/lib/service.svelte.ts
@@ -61,25 +61,11 @@ export const createOpenModal = () => {
     }
   });
 
-  function scopedOpenModal<T extends Component<any>>(
-    component: T,
-    props?: null,
-    options?: ModalOptions
-  ): Modal<T>;
-  function scopedOpenModal<T extends Component<any>>(
-    component: T,
-    props: T extends Component<infer P> ? PropsWithoutCloseModal<P> : never,
-    options?: ModalOptions
-  ): Modal<T>;
-  function scopedOpenModal<T extends Component<any>>(
-    component: T,
-    props?: any,
-    options?: ModalOptions
-  ): Modal<T> {
+  const scopedOpenModal: typeof openModal = (component, props, options) => {
     let modal = openModal(component, props as any, options);
     modals.push(modal);
     return modal;
-  }
+  };
 
   return scopedOpenModal;
 };

--- a/svelte-promise-modals/src/lib/service.test.ts
+++ b/svelte-promise-modals/src/lib/service.test.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, SvelteComponent } from 'svelte';
+import type { Component } from 'svelte';
 import { get } from 'svelte/store';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -10,17 +10,17 @@ describe('Service', () => {
   });
 
   // We don't need real components here, any object we can uniquely reference to will do
-  let Component = {} as ComponentType<SvelteComponent<{ closeModal: (value?: unknown) => void }>>;
+  let TestComponent = {} as Component<{ closeModal: (value?: unknown) => string }>;
 
   it('basics', () => {
     expect(get(count), '#count').toBe(0);
     expect(get(top), '#top').toBe(undefined);
 
-    let modal1 = openModal(Component, { foo: 'bar' });
+    let modal1 = openModal(TestComponent, { foo: 'bar' });
     expect(get(count), '#count').toBe(1);
     expect(get(top), '#top').toBe(modal1);
 
-    let modal2 = openModal(Component);
+    let modal2 = openModal(TestComponent);
     expect(get(count), '#count').toBe(2);
     expect(get(top), '#top').toBe(modal2);
 
@@ -34,7 +34,7 @@ describe('Service', () => {
   });
 
   it('modals can have results', () => {
-    let modal = openModal(Component);
+    let modal = openModal(TestComponent);
     expect(modal.result).toBe(undefined);
 
     modal.resolve('foo');
@@ -44,7 +44,7 @@ describe('Service', () => {
   });
 
   it('modals are promises', async () => {
-    let modal = openModal(Component);
+    let modal = openModal(TestComponent);
     let steps: string[] = [];
 
     modal.then(() => {
@@ -62,11 +62,11 @@ describe('Service', () => {
   });
 
   it('modals do not show up in openCount when closing', () => {
-    let modal = openModal(Component);
+    let modal = openModal(TestComponent);
 
     expect(get(count)).toBe(1);
 
-    modal.resolve();
+    modal.resolve(undefined);
 
     expect(get(count)).toBe(0);
 
@@ -79,7 +79,7 @@ describe('Service', () => {
     let steps = [];
 
     let modal = openModal(
-      Component,
+      TestComponent,
       {},
       {
         onAnimationModalOutEnd: () => {
@@ -90,7 +90,7 @@ describe('Service', () => {
 
     steps.push('modal open');
 
-    modal.resolve();
+    modal.resolve(undefined);
     steps.push('modal closing');
 
     modal.remove();

--- a/svelte-promise-modals/src/lib/service.test.ts
+++ b/svelte-promise-modals/src/lib/service.test.ts
@@ -10,7 +10,8 @@ describe('Service', () => {
   });
 
   // We don't need real components here, any object we can uniquely reference to will do
-  let TestComponent = {} as Component<{ closeModal: (value?: unknown) => string }>;
+  type TestProps = { closeModal: (value?: string) => void };
+  let TestComponent = {} as Component<TestProps> & { closeModal: (value?: string) => void };
 
   it('basics', () => {
     expect(get(count), '#count').toBe(0);

--- a/svelte-promise-modals/src/lib/types.d.ts
+++ b/svelte-promise-modals/src/lib/types.d.ts
@@ -1,5 +1,4 @@
 import type { Options as FocusTrapOptions } from 'focus-trap';
-import type { Component } from 'svelte';
 
 export type ModalOptions = {
   onAnimationModalOutEnd?(): void;

--- a/svelte-promise-modals/src/lib/types.d.ts
+++ b/svelte-promise-modals/src/lib/types.d.ts
@@ -10,7 +10,7 @@ export type ModalOptions = {
 export type FocusTrapOptions = FocusTrapOptions;
 
 export type CloseModalFn<T = void> = (value: T) => void;
-export type PropsWithoutCloseModal<T extends Component> = Omit<T, 'closeModal'>;
+export type PropsWithoutCloseModal<T> = Omit<T, 'closeModal'>;
 export type CloseModalValueParamType<T> = T extends { closeModal: CloseModalFn<infer Value> }
   ? Value
   : never;

--- a/svelte-promise-modals/vite.config.ts
+++ b/svelte-promise-modals/vite.config.ts
@@ -1,8 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig, type UserConfig } from 'vite';
-import type { UserConfig as VitestConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 
-const config: UserConfig & { test: VitestConfig['test'] } = defineConfig(({ mode }) => ({
+const config = defineConfig(({ mode }) => ({
   plugins: [sveltekit()],
   define: {
     // Eliminate in-source test code

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -10,7 +10,6 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
 		"test:unit": "vitest",

--- a/test-app/src/routes/testing/+page.svelte
+++ b/test-app/src/routes/testing/+page.svelte
@@ -103,5 +103,4 @@
   {JSON.stringify(deactivateState)}
 </pre>
 
-<!-- eslint-disable-next-line -->
 <ModalContainer options={modalContainerOptions} />

--- a/test-app/src/routes/testing/+page.svelte
+++ b/test-app/src/routes/testing/+page.svelte
@@ -11,12 +11,13 @@
 
 	const params = $page.url.searchParams;
 	const modalProps = params.get('modalProps') ? JSON.parse(params.get('modalProps')!) : {};
-	let modalContainerOptions = params.get('modalContainerOptions')
-		? JSON.parse(params.get('modalContainerOptions')!)
-		: {};
-	let openModalOptions = params.get('openModalOptions')
-		? JSON.parse(params.get('openModalOptions')!)
-		: {};
+	/* eslint-disable @typescript-eslint/no-explicit-any */
+	let modalContainerOptions = $state(
+		params.get('modalContainerOptions') ? JSON.parse(params.get('modalContainerOptions')!) : {}
+	) as any;
+	let openModalOptions = $state(
+		params.get('openModalOptions') ? JSON.parse(params.get('openModalOptions')!) : {}
+	) as any;
 
 	let activateState: unknown = $state();
 	let deactivateState: unknown = $state();
@@ -102,4 +103,5 @@
   {JSON.stringify(deactivateState)}
 </pre>
 
+<!-- eslint-disable-next-line -->
 <ModalContainer options={modalContainerOptions} />

--- a/test-app/vite.config.ts
+++ b/test-app/vite.config.ts
@@ -1,5 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	plugins: [sveltekit()],


### PR DESCRIPTION
Follow up to #119 https://github.com/mainmatter/svelte-promise-modals/issues/119#issuecomment-2636178079

- Fix Typescript wouldn't allow providing a modal without props to `openModal`
- Add Check job running svelte check