### PR TITLE
fix(release): misplaced readme

### DIFF
--- a/svelte-promise-modals/.gitignore
+++ b/svelte-promise-modals/.gitignore
@@ -12,3 +12,4 @@ vite.config.ts.timestamp-*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+README.md

--- a/svelte-promise-modals/package.json
+++ b/svelte-promise-modals/package.json
@@ -3,12 +3,16 @@
   "version": "1.0.2",
   "repository": "https://github.com/mainmatter/svelte-promise-modals",
   "license": "MIT",
+  "keywords": [
+    "svelte",
+    "modal"
+  ],
   "scripts": {
     "prepare": "svelte-kit sync",
     "dev": "vite dev",
     "preview": "vite preview",
     "build": "vite build && pnpm package",
-    "package": "svelte-kit sync && svelte-package && cp ../README.md ./dist/ && publint",
+    "package": "svelte-kit sync && svelte-package && cp ../README.md ./ && publint",
     "release": "release-it",
     "prepublishOnly": "pnpm package",
     "changelog": "lerna-changelog",


### PR DESCRIPTION
Follow up to #132 :1st_place_medal: 

This time actually verified  `npm pack` output
<img width="318" height="181" alt="image" src="https://github.com/user-attachments/assets/66a7c559-3823-41b2-bb77-b07f60bd97f8" />
