### PR TITLE
chore: migrate Renovate config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": [
+    "config:recommended"
+  ]
 }


### PR DESCRIPTION
## Summary

This is a small Renovate config migration prompted by the open Dependency Dashboard (#4): replace the deprecated `config:base` preset with `config:recommended`.

## Why

Renovate now flags this repo with **Config Migration Needed**. This keeps the current simple config shape, leaves dependency rules/credentials untouched, and lets Renovate continue with the supported recommended baseline.

## Validation

- `python3 -m json.tool renovate.json`

No package, lockfile, CI, release, registry, or credential settings changed.
